### PR TITLE
Fix: Issue #1: Crash on macOS with invalid locale (e.g. en_JP locale)

### DIFF
--- a/src/venvcleaner/main.py
+++ b/src/venvcleaner/main.py
@@ -426,15 +426,15 @@ class VenvCleanerFrame(wx.Frame):
 
 class VenvCleanerApp(wx.App):
     def __init__(self, dir_path):
+        self.dir_path = Path(dir_path)
         super().__init__()
 
-        lang_code = wx.Locale().GetSystemLanguage()
-        locale = wx.Locale(lang_code)
-
-        self.dir_path = Path(dir_path)
+    def OnInit(self):
+        self.locale = wx.Locale(wx.LANGUAGE_DEFAULT)
         self.frame = VenvCleanerFrame(self.dir_path)
         self.frame.Show()
         self.frame.venv_list.SetFocus()
+        return True
 
 # MARK: Main Function
 


### PR DESCRIPTION
Depending on the system locale, `wx.Locale.GetSystemLanguage()` may return `wx.LANGUAGE_UNKNOWN`.  
Passing `wx.LANGUAGE_UNKNOWN` to `wx.Locale` causes the assertion error below.

```text
wx._core.wxAssertionError: C++ assertion ""lang != wxLANGUAGE_UNKNOWN"" failed
```

Using `wx.LANGUAGE_DEFAULT` with `wx.Locale` has the same effect as using the value from `wx.Locale.GetSystemLanguage()`, so the code was updated to use `wx.LANGUAGE_DEFAULT`.

